### PR TITLE
Add overload for CommandService#TryExecuteAsync

### DIFF
--- a/Remora.Commands/Services/CommandService.cs
+++ b/Remora.Commands/Services/CommandService.cs
@@ -153,6 +153,26 @@ namespace Remora.Commands.Services
             return await TryExecuteAsync(searchResults, services, additionalParameters, ct);
         }
 
+        /// <summary>
+        /// Attempts to execute a command.
+        /// </summary>
+        /// <param name="command">The command to execute.</param>
+        /// <param name="services">The services available to the invocation.</param>
+        /// <param name="additionalParameters">Any additional parameters that should be available during instantiation of the command group.</param>
+        /// <param name="ct">The cancellation token for this operation.</param>
+        /// <returns>An execution result which may or may not have succeeded.</returns>
+        public async Task<Result<IResult>> TryExecuteAsync
+        (
+            BoundCommandNode command,
+            IServiceProvider services,
+            object[]? additionalParameters = null,
+            CancellationToken ct = default
+        )
+        {
+            additionalParameters ??= Array.Empty<object>();
+            return await TryExecuteAsync(new List<BoundCommandNode> { command }, services, additionalParameters, ct);
+        }
+
         private async Task<Result<IResult>> TryExecuteAsync
         (
             IReadOnlyList<BoundCommandNode> commandCandidates,

--- a/Tests/Remora.Commands.Tests/Data/Modules/BasicCommandGroup.cs
+++ b/Tests/Remora.Commands.Tests/Data/Modules/BasicCommandGroup.cs
@@ -73,5 +73,11 @@ namespace Remora.Commands.Tests.Data.Modules
         {
             return Task.FromResult<IResult>(Result.FromSuccess());
         }
+
+        [Command("predetermined-command-node")]
+        public Task<IResult> PredeterminedCommandNode()
+        {
+            return Task.FromResult<IResult>(Result.FromSuccess());
+        }
     }
 }

--- a/Tests/Remora.Commands.Tests/Services/CommandServiceTests.Preparsed.Basics.cs
+++ b/Tests/Remora.Commands.Tests/Services/CommandServiceTests.Preparsed.Basics.cs
@@ -20,11 +20,14 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Remora.Commands.Extensions;
 using Remora.Commands.Services;
+using Remora.Commands.Signatures;
 using Remora.Commands.Tests.Data.Modules;
 using Xunit;
 
@@ -238,6 +241,32 @@ namespace Remora.Commands.Tests.Services
                     (
                         "test single-named-with-long-and-short-name",
                         longValues,
+                        services
+                    );
+
+                    Assert.True(executionResult.IsSuccess);
+                }
+
+                /// <summary>
+                /// Tests whether the command service can execute a pre-determined <see cref="BoundCommandNode"/>.
+                /// </summary>
+                /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+                [Fact]
+                public async Task CanExecutePredeterminedCommandNode()
+                {
+                    var services = new ServiceCollection()
+                        .AddCommands()
+                        .AddCommandGroup<BasicCommandGroup>()
+                        .BuildServiceProvider();
+
+                    var commandService = services.GetRequiredService<CommandService>();
+
+                    List<BoundCommandNode> commands = commandService.Tree.Search("test predetermined-command-node").ToList();
+                    BoundCommandNode node = commands.Single();
+
+                    var executionResult = await commandService.TryExecuteAsync
+                    (
+                        node,
                         services
                     );
 


### PR DESCRIPTION
Added an overload for `CommandService.TryExecuteAsync` which accepts a predetermined `BoundCommandNode` object, thereby enabling a way to skip re-searching for the right command when it has already been retrieved.

A little background on why this is useful; I have an `Ephemeral` attribute which I decorate commands in my Discord bot with. When responding to an interaction, I search for the command in the tree and proceed to check the custom attributes applied to it, in order to determine if my interaction response should be ephemeral. As such, by the time I go to execute I've already found the correct command and shouldn't need to double up on finding it, by virtue of `TryExecuteAsync` only accepting the original command string.