### PR TITLE
Add ambiguous commands parameter to AmbiguousCommandInvocationError

### DIFF
--- a/Remora.Commands/Results/AmbiguousCommandInvocationError.cs
+++ b/Remora.Commands/Results/AmbiguousCommandInvocationError.cs
@@ -37,6 +37,6 @@ namespace Remora.Commands.Results
         /// <summary>
         /// Gets the potential commands that could have been executed.
         /// </summary>
-        public IReadOnlyList<PreparedCommand> CommandCandidates { get; init; }
+        public IReadOnlyList<PreparedCommand>? CommandCandidates { get; init; }
     }
 }

--- a/Remora.Commands/Results/AmbiguousCommandInvocationError.cs
+++ b/Remora.Commands/Results/AmbiguousCommandInvocationError.cs
@@ -20,7 +20,9 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
+using Remora.Commands.Services;
 using Remora.Results;
 
 namespace Remora.Commands.Results
@@ -28,7 +30,8 @@ namespace Remora.Commands.Results
     /// <summary>
     /// Raised when two or more commands pass all preconditions and are otherwise acceptable as execution candidates.
     /// </summary>
+    /// <param name="CommandCandidates">The potential commands that could have been executed.</param>
     [PublicAPI]
-    public record AmbiguousCommandInvocationError()
+    public record AmbiguousCommandInvocationError(IReadOnlyList<PreparedCommand> CommandCandidates)
         : ResultError("Two or more commands could have been executed by that.");
 }

--- a/Remora.Commands/Results/AmbiguousCommandInvocationError.cs
+++ b/Remora.Commands/Results/AmbiguousCommandInvocationError.cs
@@ -30,8 +30,13 @@ namespace Remora.Commands.Results
     /// <summary>
     /// Raised when two or more commands pass all preconditions and are otherwise acceptable as execution candidates.
     /// </summary>
-    /// <param name="CommandCandidates">The potential commands that could have been executed.</param>
     [PublicAPI]
-    public record AmbiguousCommandInvocationError(IReadOnlyList<PreparedCommand> CommandCandidates)
-        : ResultError("Two or more commands could have been executed by that.");
+    public record AmbiguousCommandInvocationError()
+        : ResultError("Two or more commands could have been executed by that.")
+    {
+        /// <summary>
+        /// Gets the potential commands that could have been executed.
+        /// </summary>
+        public IReadOnlyList<PreparedCommand> CommandCandidates { get; init; }
+    }
 }

--- a/Remora.Commands/Services/CommandService.cs
+++ b/Remora.Commands/Services/CommandService.cs
@@ -384,7 +384,7 @@ namespace Remora.Commands.Services
                     .Select(r => r.Entity)
                     .ToArray();
 
-                return new AmbiguousCommandInvocationError(ambiguousCommands);
+                return new AmbiguousCommandInvocationError() { CommandCandidates = ambiguousCommands };
             }
 
             if (preparedCommands.Any(r => r.IsSuccess))

--- a/Remora.Commands/Services/CommandService.cs
+++ b/Remora.Commands/Services/CommandService.cs
@@ -379,7 +379,12 @@ namespace Remora.Commands.Services
             // Then, check if we have to bail out at this point
             if (preparedCommands.Count(r => r.IsSuccess) > 1)
             {
-                return new AmbiguousCommandInvocationError();
+                var ambiguousCommands = preparedCommands
+                    .Where(r => r.IsSuccess)
+                    .Select(r => r.Entity)
+                    .ToArray();
+
+                return new AmbiguousCommandInvocationError(ambiguousCommands);
             }
 
             if (preparedCommands.Any(r => r.IsSuccess))

--- a/Tests/Remora.Commands.Tests/Services/CommandServiceTests.Preparsed.Ambiguity.cs
+++ b/Tests/Remora.Commands.Tests/Services/CommandServiceTests.Preparsed.Ambiguity.cs
@@ -65,6 +65,32 @@ namespace Remora.Commands.Tests.Services
                     Assert.False(executionResult.IsSuccess);
                     Assert.IsType<AmbiguousCommandInvocationError>(executionResult.Error);
                 }
+
+                /// <summary>
+                /// Tests whether the command service returns all ambiguous commands when a command route cannot be determined.
+                /// </summary>
+                /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+                [Fact]
+                public async Task ReturnsAmbiguousCanidates()
+                {
+                    var services = new ServiceCollection()
+                        .AddCommands()
+                        .AddCommandGroup<AmbiguousCommandGroup>()
+                        .BuildServiceProvider();
+
+                    var commandService = services.GetRequiredService<CommandService>();
+
+                    var values = new Dictionary<string, IReadOnlyList<string>>
+                    {
+                        { "value", new[] { "0" } }
+                    };
+
+                    var executionResult = await commandService.TryExecuteAsync("test command", values, services);
+
+                    Assert.False(executionResult.IsSuccess);
+                    Assert.IsType<AmbiguousCommandInvocationError>(executionResult.Error);
+                    Assert.Equal(2, ((AmbiguousCommandInvocationError?)executionResult.Error!)?.CommandCandidates?.Count ?? 0);
+                }
             }
         }
     }

--- a/Tests/Remora.Commands.Tests/Services/CommandServiceTests.PreparsedWithPath.Ambiguity.cs
+++ b/Tests/Remora.Commands.Tests/Services/CommandServiceTests.PreparsedWithPath.Ambiguity.cs
@@ -70,6 +70,37 @@ namespace Remora.Commands.Tests.Services
                     Assert.False(executionResult.IsSuccess);
                     Assert.IsType<AmbiguousCommandInvocationError>(executionResult.Error);
                 }
+
+                /// <summary>
+                /// Tests whether the command service returns all ambiguous commands when a command route cannot be determined.
+                /// </summary>
+                /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+                [Fact]
+                public async Task ReturnsAmbiguousCanidates()
+                {
+                    var services = new ServiceCollection()
+                        .AddCommands()
+                        .AddCommandGroup<AmbiguousCommandGroup>()
+                        .BuildServiceProvider();
+
+                    var commandService = services.GetRequiredService<CommandService>();
+
+                    var values = new Dictionary<string, IReadOnlyList<string>>
+                    {
+                        { "value", new[] { "0" } }
+                    };
+
+                    var executionResult = await commandService.TryExecuteAsync
+                    (
+                        new[] { "test", "command" },
+                        values,
+                        services
+                    );
+
+                    Assert.False(executionResult.IsSuccess);
+                    Assert.IsType<AmbiguousCommandInvocationError>(executionResult.Error);
+                    Assert.Equal(2, ((AmbiguousCommandInvocationError?)executionResult.Error!)?.CommandCandidates?.Count ?? 0);
+                }
             }
         }
     }

--- a/Tests/Remora.Commands.Tests/Services/CommandServiceTests.Raw.Ambiguity.cs
+++ b/Tests/Remora.Commands.Tests/Services/CommandServiceTests.Raw.Ambiguity.cs
@@ -58,6 +58,26 @@ namespace Remora.Commands.Tests.Services
                     Assert.False(executionResult.IsSuccess);
                     Assert.IsType<AmbiguousCommandInvocationError>(executionResult.Error);
                 }
+
+                /// <summary>
+                /// Tests whether the command service returns all ambiguous commands when a command route cannot be determined.
+                /// </summary>
+                /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+                [Fact]
+                public async Task ReturnsAmbiguousCanidates()
+                {
+                    var services = new ServiceCollection()
+                        .AddCommands()
+                        .AddCommandGroup<AmbiguousCommandGroup>()
+                        .BuildServiceProvider();
+
+                    var commandService = services.GetRequiredService<CommandService>();
+                    var executionResult = await commandService.TryExecuteAsync("test command 0", services);
+
+                    Assert.False(executionResult.IsSuccess);
+                    Assert.IsType<AmbiguousCommandInvocationError>(executionResult.Error);
+                    Assert.Equal(2, ((AmbiguousCommandInvocationError?)executionResult.Error!)?.CommandCandidates?.Count ?? 0);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds an array of ambiguous commands to the AmbigiousCommandInvocationError, which allows for recovering from this non-fatal error by optionally attempting to execute one of the commands based on some predicate (e.g. slash command).


This is, in Remora.Commands/Remora.Discord.Commands' current state, only useful if someone has a custom command handler, but it could also serve to be useful when debugging, as the commmand names/parameters can be displayed in a debugger or even in a log, instead of just a cryptic "Two or more commands could have been executed by that."