### PR TITLE
Add `MeansImplicitUse` to `Add____` extension methods

### DIFF
--- a/Remora.Commands/DependencyInjection/TreeRegistrationBuilder.cs
+++ b/Remora.Commands/DependencyInjection/TreeRegistrationBuilder.cs
@@ -55,7 +55,11 @@ public class TreeRegistrationBuilder
     /// </summary>
     /// <typeparam name="TCommandGroup">The type of the command group.</typeparam>
     /// <returns>The builder, with the group added.</returns>
-    public TreeRegistrationBuilder WithCommandGroup<TCommandGroup>() where TCommandGroup : CommandGroup
+    public TreeRegistrationBuilder WithCommandGroup
+    <
+        [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+        TCommandGroup
+    >() where TCommandGroup : CommandGroup
         => WithCommandGroup(typeof(TCommandGroup));
 
     /// <summary>

--- a/Remora.Commands/Extensions/CustomAttributeProviderExtensions.cs
+++ b/Remora.Commands/Extensions/CustomAttributeProviderExtensions.cs
@@ -41,7 +41,11 @@ public static class CustomAttributeProviderExtensions
     /// <param name="inherit">Whether inherited attributes should be considered.</param>
     /// <typeparam name="TAttribute">The attribute type.</typeparam>
     /// <returns>The found attribute, or null.</returns>
-    public static TAttribute? GetCustomAttribute<TAttribute>
+    public static TAttribute? GetCustomAttribute
+    <
+        [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+        TAttribute
+    >
     (
         this ICustomAttributeProvider attributeProvider,
         bool inherit = false

--- a/Remora.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -46,7 +46,11 @@ namespace Remora.Commands.Extensions
         /// <typeparam name="TCommandModule">The command module to register.</typeparam>
         /// <param name="serviceCollection">The service collection.</param>
         /// <returns>The service collection, with the configured modules.</returns>
-        public static IServiceCollection AddCommandGroup<TCommandModule>
+        public static IServiceCollection AddCommandGroup
+            <
+                [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+                TCommandModule
+            >
         (
             this IServiceCollection serviceCollection
         )
@@ -164,7 +168,11 @@ namespace Remora.Commands.Extensions
         /// <param name="services">The service collection.</param>
         /// <typeparam name="TParser">The type parser.</typeparam>
         /// <returns>The service collection, with the parser.</returns>
-        public static IServiceCollection AddParser<TParser>
+        public static IServiceCollection AddParser
+            <
+                [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+                TParser
+            >
         (
             this IServiceCollection services
         )
@@ -234,7 +242,11 @@ namespace Remora.Commands.Extensions
         /// Thrown if the type <typeparamref name="TCondition"/> does not implement any versions of either
         /// <see cref="ICondition{TAttribute}"/> or <see cref="ICondition{TAttribute,TData}"/>.
         /// </exception>
-        public static IServiceCollection AddCondition<TCondition>
+        public static IServiceCollection AddCondition
+            <
+                [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+                TCondition
+            >
         (
             this IServiceCollection serviceCollection
         ) where TCondition : class, ICondition

--- a/Remora.Commands/Extensions/ServiceCollectionExtensions.cs
+++ b/Remora.Commands/Extensions/ServiceCollectionExtensions.cs
@@ -66,10 +66,10 @@ public static class ServiceCollectionExtensions
     /// <returns>The service collection, with the configured modules.</returns>
     [Obsolete("Call AddCommandTree with no arguments instead, and add the group there.")]
     public static IServiceCollection AddCommandGroup
-            <
-                [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-                TCommandModule
-            >
+    <
+        [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+        TCommandModule
+    >
     (
         this IServiceCollection serviceCollection
     ) where TCommandModule : CommandGroup
@@ -161,10 +161,10 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TParser">The type parser.</typeparam>
     /// <returns>The service collection, with the parser.</returns>
     public static IServiceCollection AddParser
-            <
-                [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-                TParser
-            >
+    <
+        [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+        TParser
+    >
     (
         this IServiceCollection services
     )
@@ -235,10 +235,10 @@ public static class ServiceCollectionExtensions
     /// <see cref="ICondition{TAttribute}"/> or <see cref="ICondition{TAttribute,TData}"/>.
     /// </exception>
     public static IServiceCollection AddCondition
-            <
-                [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
-                TCondition
-            >
+    <
+        [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+        TCondition
+    >
     (
         this IServiceCollection serviceCollection
     ) where TCondition : class, ICondition


### PR DESCRIPTION
Adds the `[MeansImplicitUse`] attribute to type parameters of extension methods that add user-provided services to the container