### PR TITLE
Include attribute and value data in ConditionNotSatisfiedError

### DIFF
--- a/Remora.Commands/Results/ConditionNotSatisfiedError.cs
+++ b/Remora.Commands/Results/ConditionNotSatisfiedError.cs
@@ -21,6 +21,7 @@
 //
 
 using JetBrains.Annotations;
+using Remora.Commands.Conditions;
 using Remora.Commands.Trees.Nodes;
 using Remora.Results;
 
@@ -30,4 +31,4 @@ namespace Remora.Commands.Results;
 /// Represents a failure to satisfy a condition applied to a node in the command tree.
 /// </summary>
 [PublicAPI]
-public record ConditionNotSatisfiedError(string Message, IChildNode? Node = default) : ResultError(Message);
+public record ConditionNotSatisfiedError(string Message, ConditionAttribute Attribute, object? Entity = default, IChildNode? Node = default) : ResultError(Message);

--- a/Remora.Commands/Services/CommandService.cs
+++ b/Remora.Commands/Services/CommandService.cs
@@ -588,7 +588,8 @@ public class CommandService
                         new ConditionNotSatisfiedError
                         (
                             $"The condition \"{condition.GetType().Name}\" was not satisfied.",
-                            node
+                            (ConditionAttribute)conditionAttribute,
+                            Node: node
                         ),
                         result
                     );
@@ -670,6 +671,8 @@ public class CommandService
                         new ConditionNotSatisfiedError
                         (
                             $"The condition \"{condition.GetType().Name}\" was not satisfied.",
+                            (ConditionAttribute)conditionAttribute,
+                            value,
                             node
                         ),
                         result


### PR DESCRIPTION
This includes the ConditionAttribute instance, as well as the entity if applicable.