### PR TITLE
TimeSpanParser unintuitive edge cases

### DIFF
--- a/Remora.Commands/Parsers/Builtin/TimeSpanParser.cs
+++ b/Remora.Commands/Parsers/Builtin/TimeSpanParser.cs
@@ -40,7 +40,7 @@ public class TimeSpanParser : AbstractTypeParser<TimeSpan>
 {
     private static readonly Regex _pattern = new
     (
-        "(?<Years>\\d+(?=y))|(?<Months>\\d+(?=mo))|(?<Weeks>\\d+(?=w))|(?<Days>\\d+(?=d))|(?<Hours>\\d+(?=h))|(?<Minutes>\\d+(?=m))|(?<Seconds>\\d+(?=s))",
+        "^-|(?<Years>\\d+y)|(?<Months>\\d+mo)|(?<Weeks>\\d+w)|(?<Days>\\d+d)|(?<Hours>\\d+h)|(?<Minutes>\\d+m)|(?<Seconds>\\d+s)",
         RegexOptions.Compiled
     );
 
@@ -65,6 +65,11 @@ public class TimeSpanParser : AbstractTypeParser<TimeSpan>
             return new ValueTask<Result<TimeSpan>>(new ParsingError<TimeSpan>(value));
         }
 
+        if (value.Length != matches.Sum(x => x.Length))
+        {
+            return new ValueTask<Result<TimeSpan>>(new ParsingError<TimeSpan>(value));
+        }
+
         var timeSpan = TimeSpan.Zero;
         foreach (var match in matches.Cast<Match>())
         {
@@ -74,8 +79,14 @@ public class TimeSpanParser : AbstractTypeParser<TimeSpan>
                 .Skip(1)
                 .Select(g => (g.Name, g.Value));
 
-            foreach (var (key, groupValue) in groups)
+            foreach (var (key, groupRawValue) in groups)
             {
+                var groupValue = groupRawValue[..^1];
+                if (key is "Months")
+                {
+                    groupValue = groupValue[..^1];
+                }
+
                 if (!double.TryParse(groupValue, out var parsedGroupValue))
                 {
                     return new ValueTask<Result<TimeSpan>>(new ParsingError<TimeSpan>(value));
@@ -121,6 +132,11 @@ public class TimeSpanParser : AbstractTypeParser<TimeSpan>
                     };
                 }
             }
+        }
+
+        if (value[0] == '-')
+        {
+            timeSpan = -timeSpan;
         }
 
         return new ValueTask<Result<TimeSpan>>(timeSpan);

--- a/Tests/Remora.Commands.Tests/Parsers/TimeSpanParserTests.cs
+++ b/Tests/Remora.Commands.Tests/Parsers/TimeSpanParserTests.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Remora.Commands.Parsers;
+using Remora.Commands.Results;
 using Xunit;
 
 namespace Remora.Commands.Tests.Parsers;
@@ -86,7 +87,23 @@ public class TimeSpanParserTests
 
                 return then - now + TimeSpan.FromMinutes(1);
             })
+        ],
+        [
+            "-1m",
+            new Func<TimeSpan>(() => -TimeSpan.FromMinutes(1))
         ]
+    ];
+
+    /// <summary>
+    /// Gets a set of various test cases that aren't parseable.
+    /// </summary>
+    public static IEnumerable<object?[]> InvalidCases =>
+    [
+        ["x60sx"],
+        ["1m-60s"],
+        ["s"],
+        [string.Empty],
+        [null],
     ];
 
     /// <summary>
@@ -105,5 +122,22 @@ public class TimeSpanParserTests
 
         Assert.True(result.IsSuccess);
         Assert.Equal(expected(), result.Entity);
+    }
+
+    /// <summary>
+    /// Tests whether the parser outputs errors in case of malformed inputs.
+    /// </summary>
+    /// <param name="value">The value to parse.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Theory]
+    [MemberData(nameof(InvalidCases))]
+    public async Task DoesntAcceptInvalidInput(string? value)
+    {
+        var parser = new TimeSpanParser();
+
+        var result = await parser.TryParseAsync(value);
+
+        Assert.False(result.IsSuccess);
+        Assert.IsType<ParsingError<TimeSpan>>(result.Error);
     }
 }


### PR DESCRIPTION
The current custom regex-based TimeSpanParser doesn't check if there is excessive text in the string. Because of that, even strings like `x60sx` are matched properly, x'es being ignored. Even worse so, this also goes for `-` sign in front of the TimeSpan specification. This can lead to confusion as `-60s` means the same as `60s`.

This PR aims to change that,
1. It is checked that there are no excessive characters
2. Support for negative TimeSpans is implemented (it was already supported by TimeSpan.TryParse when the entered time span was in format parseable by this)

Tbh I don't really understand the group matches, I tried multiple approaches that didn't work, mostly based on matching the whole string rather than matching just the individual parts, but I couldn't get it to match the groups. I ended up with a solution with a few changes from the current one. The change I dislike the most is that lookahead is removed, and instead the last character is trimmed in the foreach for matching groups. For months two characters are trimmed. This works, but if you have better ideas on how to implement it, I welcome that.