### PR TITLE
fix: ParameterBuilder shouldn't append itself to the command

### DIFF
--- a/Remora.Commands/Builders/CommandParameterBuilder.cs
+++ b/Remora.Commands/Builders/CommandParameterBuilder.cs
@@ -60,10 +60,8 @@ public class CommandParameterBuilder
     {
         _name = string.Empty;
         _builder = builder;
-        _attributes = new();
-        _conditions = new();
-        builder.Parameters.Add(this);
-
+        _attributes = [];
+        _conditions = [];
         _parameterType = type;
     }
 

--- a/Tests/Remora.Commands.Tests/Builders/CommandBuilderTests.cs
+++ b/Tests/Remora.Commands.Tests/Builders/CommandBuilderTests.cs
@@ -65,11 +65,11 @@ public class CommandBuilderTests
         var commandBuilder = new CommandBuilder()
             .WithName("test")
             .WithInvocation((_, _, _) => default)
-            .WithDescription("A test command.");
-
-        _ = new CommandParameterBuilder(commandBuilder, typeof(string))
-            .WithName("test")
-            .WithDescription("A test parameter.");
+            .WithDescription("A test command.")
+            .AddParameter(typeof(string))
+                .WithName("test")
+                .WithDescription("A test parameter.")
+                .Finish();
 
         var command = commandBuilder.Build(rootNode);
 
@@ -90,15 +90,15 @@ public class CommandBuilderTests
         var commandBuilder = new CommandBuilder()
             .WithName("test")
             .WithInvocation((_, _, _) => default)
-            .WithDescription("A test command.");
-
-        _ = new CommandParameterBuilder(commandBuilder, typeof(string))
-            .WithName("test")
-            .WithDescription("A test parameter.");
-
-        _ = new CommandParameterBuilder(commandBuilder, typeof(int))
-            .WithName("test2")
-            .WithDescription("A second test parameter.");
+            .WithDescription("A test command.")
+            .AddParameter(typeof(string))
+                .WithName("test")
+                .WithDescription("A test parameter.")
+                .Finish()
+            .AddParameter(typeof(int))
+                .WithName("test2")
+                .WithDescription("A second test parameter.")
+                .Finish();
 
         var command = commandBuilder.Build(rootNode);
 


### PR DESCRIPTION
The parameter list remains internal (visible) for purposes of allowing CommandShape to access its list. This should *probably* be publicly exposed as `IReadOnlyList` as per proper API standards.

This fixes an issue where using the fluent API to create commands dynamically/not based off a runtime type would have duplicated parameters due to the parameter builder attaching itself while the method also appended the builder.