### PR TITLE
Fixes #32 Greedy tokenization fix

### DIFF
--- a/Remora.Commands/Tokenization/TokenizingEnumerator.cs
+++ b/Remora.Commands/Tokenization/TokenizingEnumerator.cs
@@ -33,6 +33,7 @@ public ref struct TokenizingEnumerator
 {
     private readonly TokenizerOptions _tokenizerOptions;
     private bool _isInCombinedShortNameSegment;
+    private bool _isInAssignmentValueSegment;
     private ReadOnlySpan<char> _segment;
     private SpanSplitEnumerator _splitEnumerator;
 
@@ -51,6 +52,7 @@ public ref struct TokenizingEnumerator
         _tokenizerOptions = tokenizerOptions ?? new TokenizerOptions();
 
         _isInCombinedShortNameSegment = default;
+        _isInAssignmentValueSegment = default;
         _segment = default;
         _splitEnumerator = new SpanSplitEnumerator(value, _tokenizerOptions);
         this.Current = default;
@@ -76,6 +78,7 @@ public ref struct TokenizingEnumerator
             }
 
             _isInCombinedShortNameSegment = false;
+            _isInAssignmentValueSegment = false;
             _segment = _splitEnumerator.Current;
         }
 
@@ -97,9 +100,10 @@ public ref struct TokenizingEnumerator
                 span = span[1..];
             }
         }
-        else if (span.StartsWith("="))
+        else if (_isInAssignmentValueSegment && span.StartsWith("="))
         {
             span = span[1..];
+            _isInAssignmentValueSegment = false;
         }
         else if (_isInCombinedShortNameSegment)
         {
@@ -123,6 +127,7 @@ public ref struct TokenizingEnumerator
             if (assignmentIndex > 0)
             {
                 remainder = span[assignmentIndex..];
+                _isInAssignmentValueSegment = true;
                 span = span[..assignmentIndex];
             }
         }

--- a/Tests/Remora.Commands.Tests/Tokenization/TokenizingEnumeratorTests.cs
+++ b/Tests/Remora.Commands.Tests/Tokenization/TokenizingEnumeratorTests.cs
@@ -56,6 +56,9 @@ public class TokenizingEnumeratorTests
     [InlineData("-xvf=value", new[] { ShortName, ShortName, ShortName, Value }, new[] { "x", "v", "f", "value" })]
     [InlineData("-xvf=\"booga wooga\"", new[] { ShortName, ShortName, ShortName, Value }, new[] { "x", "v", "f", "booga wooga" })]
     [InlineData("--a -10", new[] { LongName, Value }, new[] { "a", "-10" })]
+    [InlineData("1 == 1", new[] { Value, Value, Value }, new[] { "1", "==", "1" })]
+    [InlineData("1==1", new[] { Value }, new[] { "1==1" })]
+    [InlineData("--a==", new[] { LongName, Value }, new[] { "a", "=" })]
     internal void TokenizesStringCorrectly
     (
         string value,
@@ -99,6 +102,8 @@ public class TokenizingEnumeratorTests
     [InlineData("-xvf=value", new[] { ShortName, ShortName, ShortName, Value }, new[] { "x", "v", "f", "value" })]
     [InlineData("-xvf=\"booga wooga\"", new[] { ShortName, ShortName, ShortName, Value }, new[] { "x", "v", "f", "\"booga wooga\"" })]
     [InlineData("--a -10", new[] { LongName, Value }, new[] { "a", "-10" })]
+    [InlineData("1 == 1", new[] { Value, Value, Value }, new[] { "1", "==", "1" })]
+    [InlineData("--a==", new[] { LongName, Value }, new[] { "a", "=" })]
     [InlineData("-a \"\"", new[] { ShortName, Value }, new[] { "a", "\"\"" })]
     internal void RetainsQuotationMarksCorrectly
     (


### PR DESCRIPTION
Fixes tokenization bug where greedy string parameters could lose equals signs from user input.

Tokenizer now only strips leading = when processing remainder of an option assignment segment. Normal positional and greedy value tokens preserve equals signs.

Added regression coverage for:
```
1 == 1
--a==
```